### PR TITLE
Workaround to avoid that the information of other lobbies is blocked by an inaccessible one

### DIFF
--- a/src/SokuMod/Connection.cpp
+++ b/src/SokuMod/Connection.cpp
@@ -27,6 +27,14 @@ void Connection::_netLoop()
 	size_t recvSize = 0;
 
 	while (true) {
+		if (!this->_connected)
+			return;
+
+		if (!this->_hasConnected) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			continue;
+		}
+
 		try {
 			recvSize += (recvSizeAdded = this->_socket.read(buffer + recvSize, sizeof(buffer) - recvSize));
 		} catch (std::exception &e) {
@@ -45,8 +53,6 @@ void Connection::_netLoop()
 			return;
 		}
 
-		if (!this->_connected)
-			return;
 		if (recvSizeAdded == 0) {
 			this->_init = false;
 			this->_connected = false;
@@ -64,9 +70,10 @@ void Connection::_netLoop()
 }
 
 Connection::Connection(const std::string &host, unsigned short port, const Player &initParams) :
+	_host(host),
+	_port(port),
 	_initParams(initParams)
 {
-	this->_socket.connect(host, port);
 }
 
 Connection::~Connection()
@@ -74,7 +81,10 @@ Connection::~Connection()
 	this->_init = false;
 	if (this->onDisconnect)
 		this->onDisconnect();
-	this->_socket.disconnect();
+	if (this->_connectThread.joinable())
+		this->_connectThread.join();
+	if (this->_hasConnected)
+		this->_socket.disconnect();
 	if (this->_netThread.joinable())
 		this->_netThread.join();
 	if (this->_posThread.joinable())
@@ -91,6 +101,16 @@ void Connection::error(const std::string &msg)
 
 void Connection::startThread()
 {
+	this->_connectThread = std::thread([this](){
+		try {
+			this->_socket.connect(this->_host, this->_port);
+			this->_hasConnected = true;
+		} catch (std::exception &e) {
+			std::lock_guard<std::mutex> playerMutexGuard(this->_playerMutex);
+			std::lock_guard<std::mutex> meMutexGuard(this->meMutex);
+			this->error(e.what());
+		}
+	});
 	this->_netThread = std::thread{&Connection::_netLoop, this};
 }
 
@@ -116,6 +136,11 @@ void Connection::send(const void *packet, size_t size)
 bool Connection::isInit() const
 {
 	return this->_init;
+}
+
+bool Connection::hasConnected() const
+{
+	return this->_hasConnected;
 }
 
 bool Connection::isConnected() const

--- a/src/SokuMod/Connection.hpp
+++ b/src/SokuMod/Connection.hpp
@@ -33,6 +33,10 @@ private:
 	mutable std::mutex _playerMutex;
 	std::thread _netThread;
 	std::thread _posThread;
+	std::thread _connectThread;
+	std::string _host;
+	unsigned short _port;
+	bool _hasConnected = false;
 	bool _connected = true;
 	bool _init = false;
 	char _uniqueId[16];
@@ -91,6 +95,7 @@ public:
 	void send(const void *packet, size_t size);
 	bool isInit() const;
 	bool isConnected() const;
+	bool hasConnected() const;
 	const LobbyInfo &getLobbyInfo() const;
 	Player *getMe();
 	const Player *getMe() const;

--- a/src/SokuMod/LobbyMenu.cpp
+++ b/src/SokuMod/LobbyMenu.cpp
@@ -215,7 +215,7 @@ void LobbyMenu::_netLoop()
 
 		this->_connectionsMutex.lock();
 		for (auto &c : this->_connections)
-			if (c->c && !c->c->isInit() && c->c->isConnected())
+			if (c->c && c->c->hasConnected() && !c->c->isInit() && c->c->isConnected())
 				c->c->send(&ping, sizeof(ping));
 		this->_connectionsMutex.unlock();
 		for (int i = 0; i < 20 && this->_open; i++)


### PR DESCRIPTION
It is just a temporary workaround, and Soku will still wait for the end of all these connections when returning to the title menu.
To completely solve the problem, I think a non-blocking socket should be used when establishing the connection, and we should change the way to use the socket, at least when establishing the connection.